### PR TITLE
Training program

### DIFF
--- a/BangazonSprint/Controllers/TrainingProgramController.cs
+++ b/BangazonSprint/Controllers/TrainingProgramController.cs
@@ -1,46 +1,240 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
+using BangazonSprint.Models;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using static Microsoft.EntityFrameworkCore.DbLoggerCategory.Database;
 
 namespace BangazonSprint.Controllers
 {
+
+    /*GET
+    POST
+    PUT
+    DELETE (but only if the start date is in the future)
+    User should be able to GET a list, and GET a single item.
+    Employees who signed up for a training program should be included in the response
+    Should be able to view only programs starting today, or in the future, with the ?completed=false query string parameter.*/
+
     [Route("api/[controller]")]
     [ApiController]
     public class TrainingProgramController : ControllerBase
     {
+
+        private readonly IConfiguration _config;
+
+        public TrainingProgramController(IConfiguration config)
+        {
+            _config = config;
+        }
+
+        public SqlConnection Connection
+        {
+            get
+            {
+                return new SqlConnection(_config.GetConnectionString("DefaultConnection"));
+            }
+        }
+
         // GET: api/TrainingProgram
         [HttpGet]
-        public IEnumerable<string> Get()
+        public List<TrainingProgram> GetTrainingProgram(string completed, string q)
         {
-            return new string[] { "value1", "value2" };
-        }
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    if (completed == "false")
+                    {
+                        cmd.CommandText = $@"Select tp.id, tp.[Name], tp.StartDate, tp.EndDate, tp.MaxAttendees,
+                                        et.TrainingProgramId, et.EmployeeId, e.FirstName, e.LastName, d.id AS departmentid, d.Name AS deptName
+                                             From TrainingProgram tp
+                                            right JOIN EmployeeTraining et ON et.TrainingProgramId = tp.id
+                                            left JOIN Employee e ON e.id = et.EmployeeId
+                                            join Department d ON d.id = e.DepartmentId
+                                            Where EndDate >= GetDate()";
+                    }
+                    else
+                    {
+                        cmd.CommandText = $@"Select tp.id, tp.[Name], tp.StartDate, tp.EndDate, tp.MaxAttendees,
+                                        et.TrainingProgramId, et.EmployeeId, e.FirstName, e.LastName, e.departmentid, d.id AS departmentid, d.Name AS deptName
+                                             From TrainingProgram tp
+                                            right JOIN EmployeeTraining et ON et.TrainingProgramId = tp.id
+                                            left JOIN Employee e ON e.id = et.EmployeeId
+                                            join Department d ON d.id = e.DepartmentId
+                                    WHERE 1 = 1";
+                    }
+                    SqlDataReader reader = cmd.ExecuteReader();
 
-        // GET: api/TrainingProgram/5
+                    Dictionary<int, TrainingProgram> trainingprogram = new Dictionary<int, TrainingProgram>();
+                    while (reader.Read())
+                    {
+                        int trainingprogramid = reader.GetInt32(reader.GetOrdinal("trainingprogramid"));
+
+                        if (!trainingprogram.ContainsKey(trainingprogramid))
+                        {
+                            TrainingProgram training = new TrainingProgram
+                            {
+                                Id = trainingprogramid,
+                                Name = reader.GetString(reader.GetOrdinal("Name")),
+                                StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
+                                EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
+                                MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees")),
+                                employeeList = new List<Employee>(),
+                            };
+                            trainingprogram.Add(trainingprogramid, training);
+                        }
+                        if (!reader.IsDBNull(reader.GetOrdinal("employeeid")))
+                        {
+                            TrainingProgram currentTrainingProgram = trainingprogram[trainingprogramid];
+                            currentTrainingProgram.employeeList.Add(
+                            new Employee
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("employeeid")),
+                                FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
+                                LastName = reader.GetString(reader.GetOrdinal("LastName")),
+                                DepartmentId = reader.GetInt32(reader.GetOrdinal("departmentid")),
+                                department = new Department
+                                {
+                                    Id = reader.GetInt32(reader.GetOrdinal("departmentid")),
+                                    Name = reader.GetString(reader.GetOrdinal("deptName"))
+                                }
+
+                              }
+                               
+                            );
+
+                        }
+
+                    }
+                            reader.Close();
+                            return trainingprogram.Values.ToList();
+                        }
+                    }
+                }
+ 
+
+
+        // GET: api/Customer/5
         [HttpGet("{id}", Name = "GetSingleTrainingProgram")]
-        public string Get(int id)
+        public List<TrainingProgram> GetTrainingProgram(int id, string include)
         {
-            return "value";
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"Select tp.id AS trainingprogramid, tp.[Name], tp.StartDate, tp.EndDate, tp.MaxAttendees,
+                                        et.TrainingProgramId, et.EmployeeId, e.FirstName, e.LastName, e.departmentid, d.id AS departmentid, d.Name AS deptName
+                                             From TrainingProgram tp
+                                            right JOIN EmployeeTraining et ON et.TrainingProgramId = tp.id
+                                            left JOIN Employee e ON e.id = et.EmployeeId
+                                            join Department d ON d.id = e.DepartmentId
+                                             WHERE tp.id = @id";
+                    cmd.Parameters.Add(new SqlParameter("@id", id));
+                    SqlDataReader reader = cmd.ExecuteReader();
+
+                    Dictionary<int, TrainingProgram> trainingprogram = new Dictionary<int, TrainingProgram>();
+                    while (reader.Read())
+                    {
+                        int trainingprogramid = reader.GetInt32(reader.GetOrdinal("trainingprogramid"));
+
+                        if (!trainingprogram.ContainsKey(trainingprogramid))
+                        {
+                            TrainingProgram training = new TrainingProgram
+                            {
+                                Id = trainingprogramid,
+                                Name = reader.GetString(reader.GetOrdinal("Name")),
+                                StartDate = reader.GetDateTime(reader.GetOrdinal("StartDate")),
+                                EndDate = reader.GetDateTime(reader.GetOrdinal("EndDate")),
+                                MaxAttendees = reader.GetInt32(reader.GetOrdinal("MaxAttendees")),
+                                employeeList = new List<Employee>(),
+                            };
+                            trainingprogram.Add(trainingprogramid, training);
+                        }
+                        if (!reader.IsDBNull(reader.GetOrdinal("employeeid")))
+                        {
+                            TrainingProgram currentTrainingProgram = trainingprogram[trainingprogramid];
+                            currentTrainingProgram.employeeList.Add(
+                            new Employee
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("employeeid")),
+                                FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
+                                LastName = reader.GetString(reader.GetOrdinal("LastName")),
+                                DepartmentId = reader.GetInt32(reader.GetOrdinal("departmentid")),
+                                department = new Department
+                                {
+                                    Id = reader.GetInt32(reader.GetOrdinal("departmentid")),
+                                    Name = reader.GetString(reader.GetOrdinal("deptName"))
+                                }
+
+                            }
+
+                            );
+
+                        }
+
+                    }
+                    reader.Close();
+                    return trainingprogram.Values.ToList();
+                }
+            }
         }
 
-        // POST: api/TrainingProgram
+        // POST: api/Customer
         [HttpPost]
-        public void Post([FromBody] string value)
+        public async Task<IActionResult> Post([FromBody] TrainingProgram newTrainingProgram)
         {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"INSERT INTO TrainingProgram (Name, StartDate, EndDate, MaxAttendees)
+                                                OUTPUT INSERTED.Id
+                                                VALUES (@Name, @StartDate, @EndDate, @MaxAttendees);";
+                    cmd.Parameters.Add(new SqlParameter("@Name", newTrainingProgram.Name));
+                    cmd.Parameters.Add(new SqlParameter("@StartDate", newTrainingProgram.StartDate));
+                    cmd.Parameters.Add(new SqlParameter("@EndDate", newTrainingProgram.EndDate));
+                    cmd.Parameters.Add(new SqlParameter("@MaxAttendees", newTrainingProgram.MaxAttendees));
+
+                    int newId = (int)cmd.ExecuteScalar();
+                    newTrainingProgram.Id = newId;
+                    return CreatedAtRoute("GetSingleTrainingProgram", new { id = newId }, newTrainingProgram);
+
+                }
+            }
         }
 
         // PUT: api/TrainingProgram/5
         [HttpPut("{id}")]
-        public void Put(int id, [FromBody] string value)
+        public void Put(int id, [FromBody] TrainingProgram training)
         {
-        }
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"UPDATE TrainingProgram
+                                                SET Name = @Name, 
+                                                    StartDate = @StartDate,
+                                                    EndDate = @EndDate,
+                                                    MaxAttendees = @MaxAttendees
+                                                WHERE id = @id;";
+                    cmd.Parameters.Add(new SqlParameter("@Name", training.Name));
+                    cmd.Parameters.Add(new SqlParameter("@StartDate", training.StartDate));
+                    cmd.Parameters.Add(new SqlParameter("@EndDate", training.EndDate));
+                    cmd.Parameters.Add(new SqlParameter("@MaxAttendees", training.MaxAttendees));
+                    cmd.Parameters.Add(new SqlParameter("@id", id));
 
-        // DELETE: api/ApiWithActions/5
-        [HttpDelete("{id}")]
-        public void Delete(int id)
-        {
+                    cmd.ExecuteNonQuery();
+                }
+            }
         }
     }
 }

--- a/BangazonSprint/Controllers/TrainingProgramController.cs
+++ b/BangazonSprint/Controllers/TrainingProgramController.cs
@@ -236,5 +236,59 @@ namespace BangazonSprint.Controllers
                 }
             }
         }
+        [HttpDelete("{id}")]
+        public IActionResult Delete([FromRoute] int id)
+        {
+            try
+            {
+                using (SqlConnection conn = Connection)
+                {
+                    conn.Open();
+                    using (SqlCommand cmd = conn.CreateCommand())
+                    {
+                        cmd.CommandText = @"DELETE FROM TrainingProgram WHERE Id = @id";
+                        cmd.Parameters.Add(new SqlParameter("@id", id));
+
+                        int rowsAffected = cmd.ExecuteNonQuery();
+                        if (rowsAffected > 0)
+                        {
+                            return new StatusCodeResult(StatusCodes.Status204NoContent);
+                        }
+                        throw new Exception("No rows affected");
+                    }
+                }
+            }
+            catch (Exception)
+            {
+                if (!TrainingProgramExists(id))
+                {
+                    return NotFound();
+                }
+                else
+                {
+                    throw;
+                }
+            }
+        }
+
+        private bool TrainingProgramExists(int id)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        SELECT Id, Name, StartDate, EndDate, MaxAttendees
+                        FROM TrainingProgram
+                        WHERE Id = @id";
+                    cmd.Parameters.Add(new SqlParameter("@id", id));
+
+                    SqlDataReader reader = cmd.ExecuteReader();
+                    return reader.Read();
+                }
+            }
+        }
     }
 }
+

--- a/BangazonSprint/Models/TrainingProgram.cs
+++ b/BangazonSprint/Models/TrainingProgram.cs
@@ -3,9 +3,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace BangazonSprintStartUp.Models
+namespace BangazonSprint.Models
 {
     public class TrainingProgram
     {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public DateTime StartDate { get; set; }
+        public DateTime EndDate { get; set; }
+        public int MaxAttendees { get; set; }
+        public List<Employee> employeeList { get; set; }
     }
 }

--- a/TestBangazonAPI/CustomerTest.cs
+++ b/TestBangazonAPI/CustomerTest.cs
@@ -48,7 +48,7 @@ namespace TestBangazonAPI
             using (var client = new APIClientProvider().Client)
             {
 
-                var response = await client.GetAsync("/api/paymenttype");
+                var response = await client.GetAsync("/api/customer");
 
                 string responseBody = await response.Content.ReadAsStringAsync();
                 var customerList = JsonConvert.DeserializeObject<List<Customer>>(responseBody);

--- a/TestBangazonAPI/TrainingProgramTest.cs
+++ b/TestBangazonAPI/TrainingProgramTest.cs
@@ -1,0 +1,110 @@
+﻿using BangazonSprint.Models;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace TestBangazonAPI
+{
+    public class TrainingProgramTest
+    {
+        [Fact]
+        public async Task Test_Get_All_TrainingPrograms()
+        {
+            using (var client = new APIClientProvider().Client)
+            {
+               
+                var response = await client.GetAsync("/api/TrainingProgram");
+
+
+                string responseBody = await response.Content.ReadAsStringAsync();
+                var orderList = JsonConvert.DeserializeObject<List<TrainingProgram>>(responseBody);
+
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+                Assert.True(orderList.Count > 0);
+            }
+        }
+
+        [Fact]
+        public async Task Test_Create_Training()
+        {
+
+            using (var client = new APIClientProvider().Client)
+            {
+               
+                var getOldList = await client.GetAsync("/api/trainingprogram");
+                getOldList.EnsureSuccessStatusCode();
+
+                string getOldListBody = await getOldList.Content.ReadAsStringAsync();
+                var oldList = JsonConvert.DeserializeObject<List<TrainingProgram>>(getOldListBody);
+
+
+
+                TrainingProgram trainingprogram = new TrainingProgram
+                {
+                    Name = "Learn to Swim",
+                    StartDate = new DateTime(2019, 04, 20),
+                    EndDate = new DateTime(2019, 04, 24),
+                    MaxAttendees = 15
+                };
+
+                var modifiedOrderAsJSON = JsonConvert.SerializeObject(trainingprogram);
+
+                var response = await client.PostAsync(
+                    "/api/trainingprogram",
+                    new StringContent(modifiedOrderAsJSON, Encoding.UTF8, "application/json")
+                );
+
+                string responseBody = await response.Content.ReadAsStringAsync();
+
+            
+                var getOrder = await client.GetAsync("/api/trainingprogram");
+                var newProgram = JsonConvert.DeserializeObject<TrainingProgram>(responseBody);
+
+
+                Assert.Equal(HttpStatusCode.OK, getOrder.StatusCode);
+                Assert.Equal(15, newProgram.MaxAttendees);
+            }
+        }
+
+        [Fact]
+        public async Task Test_Modify_TrainingProgram()
+        {
+
+            using (var client = new APIClientProvider().Client)
+            {
+
+                int newmax = 15;
+                TrainingProgram trainingprogram = new TrainingProgram
+                {
+                    Name = "How To Sell Cars",
+                    StartDate = new DateTime(2020, 02, 14),
+                    EndDate = new DateTime(2019, 02, 15),
+                    MaxAttendees = newmax
+                };
+
+                var modifiedDeptAsJSON = JsonConvert.SerializeObject(trainingprogram);
+
+                var response = await client.PutAsync(
+                    "/api/TrainingProgram/1",
+                    new StringContent(modifiedDeptAsJSON, Encoding.UTF8, "application/json")
+                );
+                string responseBody = await response.Content.ReadAsStringAsync();
+
+                Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+                var getmax = await client.GetAsync("/api/TrainingProgram");
+                getmax.EnsureSuccessStatusCode();
+
+                string getBody = await getmax.Content.ReadAsStringAsync();
+               var newMaxAttendees = JsonConvert.DeserializeObject<List<TrainingProgram>>(getBody);
+                Assert.Equal(HttpStatusCode.OK, getmax.StatusCode);
+                Assert.Equal(newmax, newMaxAttendees[0].MaxAttendees);
+            }
+        }
+    }
+}


### PR DESCRIPTION
 # Description
The user should be able to get all Training Programs, post a training program, edit a program, and delete a program.
    GET
    POST
    PUT
    DELETE (but only if the start date is in the future)
    User should be able to GET a list, and GET a single item.
    Employees who signed up for a training program should be included in the response
    Should be able to view only programs starting today, or in the future, with the ?completed=false 
    query string parameter.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Testing Instructions for Change Made

fetch --all
git checkout mr-TrainingProgram
Make sure you get all training programs that the completion date is in the future
Can get a single Training program with the same stipulations
Post a Training Program
Put a Training Program
Delete a Training Program 
using PostMan


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added test instructions that prove my fix is effective or that my feature works